### PR TITLE
Fix eggdrop 1.8 compatibility for stats.mod 1.4.1 / git

### DIFF
--- a/UPDATES
+++ b/UPDATES
@@ -3,6 +3,7 @@ Changes in Stats.mod: (since v1.0.1)
 1.5.0
 - Now also works with eggdrop 1.8. stats 1.4.1 does not work with
   eggdrop 1.8-rc1+ / git ac1b6ed3f4f949affd7090a053787fb664f4e292+.
+- Fix crash if no language selected.
 
 1.4.1
 - Now also works with eggdrop 1.8.

--- a/UPDATES
+++ b/UPDATES
@@ -1,5 +1,9 @@
 Changes in Stats.mod: (since v1.0.1)
 --------------------
+1.5.0
+- Now also works with eggdrop 1.8. stats 1.4.1 does not work with
+  eggdrop 1.8-rc1+ / git ac1b6ed3f4f949affd7090a053787fb664f4e292+.
+
 1.4.1
 - Now also works with eggdrop 1.8.
 

--- a/core/slang.c
+++ b/core/slang.c
@@ -245,7 +245,7 @@ static char *getslang(int id)
   char *text;
 
   if (!glob_slang) {
-    putlog(LOG_MISC, "*", "WARNING! No language selected! (getslang())");
+    putlog(LOG_MISC, "*", "Stats warning: no language selected. (getslang())");
     return "NOLANG";
   }
   text = slang_id_get(glob_slang->ids, id);
@@ -262,7 +262,7 @@ static char *getdur(int idx)
 
   Assert((idx >= 0) && (idx < DURATIONS));
   if (!glob_slang) {
-    putlog(LOG_MISC, "*", "WARNING! No language selected! (getdur())");
+    putlog(LOG_MISC, "*", "Stats warning: no language selected. (getdur())");
     return "NOLANG";
   }
   text = slang_duration_get(glob_slang->durations, idx);
@@ -279,7 +279,7 @@ static char *getslangtype(char *type)
   char *stype;
 
   if (!glob_slang) {
-    putlog(LOG_MISC, "*", "WARNING! No language selected! (getslangtype())");
+    putlog(LOG_MISC, "*", "Stats warning: no language selected. (getslangtype())");
     return "NOLANG";
   }
   stype = slang_type_get(glob_slang->types, type);
@@ -294,7 +294,7 @@ static int slangtypetoi(char *slangtype)
   char *type;
 
   if (!glob_slang) {
-    putlog(LOG_MISC, "*", "WARNING! No language selected! (slangtypetoi())");
+    putlog(LOG_MISC, "*", "Stats warning: no language selected. (slangtypetoi())");
     return T_ERROR;
   }
   type = slang_type_slang2type(glob_slang->types, slangtype);
@@ -312,7 +312,7 @@ static char *getslang_first(int id)
   char *text;
 
   if (!glob_slang) {
-    putlog(LOG_MISC, "*", "WARNING! No language selected! (getslang())");
+    putlog(LOG_MISC, "*", "Stats warning: no language selected. (getslang_first())");
     return "NOLANG";
   }
   text = slang_id_get_first(glob_slang->ids, id);
@@ -325,6 +325,9 @@ static char *getslang_first(int id)
 
 static char *getslang_next()
 {
+  if (!glob_slang) {
+    return NULL;
+  }
   return slang_id_get_next();
 }
 #endif

--- a/core/userrec.c
+++ b/core/userrec.c
@@ -282,11 +282,8 @@ static void welcome_suser(char *nick, struct stats_userlist *u, char *chan)
   glob_user = u;
   glob_nick = nick;
   glob_slang = slang_find(coreslangs, slang_chanlang_get(chanlangs, chan));
-  if ((text = getslang_first(500))) {
+  for (text = getslang_first(500); text; text = getslang_next())
     dprintf(DP_HELP, "NOTICE %s :%s\n", nick, text);
-    while ((text = getslang_next()))
-      dprintf(DP_HELP, "NOTICE %s :%s\n", nick, text);
-  }
 }
 
 static int listsuser(locstats *ls, char *chan)

--- a/stats.c
+++ b/stats.c
@@ -31,7 +31,7 @@
 
 #define MAKING_STATS
 #define MODULE_NAME "stats"
-#define MODULE_VERSION "1.4.1-dev"
+#define MODULE_VERSION "1.5.0"
 #ifndef NO_EGG
 #include "../module.h"
 #include "../irc.mod/irc.h"
@@ -467,7 +467,7 @@ char *stats_start(Function * global_funcs)
   chanlangs = NULL;
   slang_glob_init();
   Context;
-  module_register(MODULE_NAME, stats_table, 1, 4);
+  module_register(MODULE_NAME, stats_table, 1, 5);
   if (!(irc_funcs = module_depend(MODULE_NAME, "irc", 1, 0)))
     return "You need the irc module to use the stats module.";
   if (!(server_funcs = module_depend(MODULE_NAME, "server", 1, 0)))
@@ -475,16 +475,8 @@ char *stats_start(Function * global_funcs)
   if (!(channels_funcs = module_depend(MODULE_NAME, "channels", 1, 0)))
     return "You need the channels module to use the stats module.";
   if (!module_depend(MODULE_NAME, "eggdrop", 108, 0)) {
-    if (!module_depend(MODULE_NAME, "eggdrop", 107, 0)) {
-      if (!module_depend(MODULE_NAME, "eggdrop", 106, 0)) {
-        if (!module_depend(MODULE_NAME, "eggdrop", 105, 0)) {
-          if (!module_depend(MODULE_NAME, "eggdrop", 104, 0)) {
-            module_undepend(MODULE_NAME);
-            return "Sorry, stats.mod doesn't work with this eggdrop version.";
-          }
-        }
-      }
-    }
+    module_undepend(MODULE_NAME);
+    return "Sorry, stats.mod requires Eggdrop 1.8.0 or later.";
   }
 #ifndef OLDBOT
   livestats_timeout = 10;


### PR DESCRIPTION
stats.mod doesnt build with eggdrop 1.8-rc1+ due to changed module API (function `answer()`) with eggdrop commit https://github.com/eggheads/eggdrop/commit/12cff4496d1bac1b3f6876a54590dc5c522de7ad. This PR fixes compilation with eggdrop 1.8.

Developer test against eggdrop git https://github.com/eggheads/eggdrop/tree/f59fb68811437536ee86dedb1ca23a31b48a5cca (20201206):
```
.load stats
[01:37:45] tcl: builtin dcc call: *dcc:loadmod -HQ 1 stats
[01:37:45] mem: memtbl size doubled to 8192.
[01:37:45] Creating nopubstats (type 1)
[01:37:45] Creating quietstats (type 1)
[01:37:45] Creating nostats (type 1)
[01:37:45] Stats.mod v1.5.0 loaded.
[01:37:45] Module loaded: stats           
[01:37:45] #-HQ# loadmod stats
Module loaded: stats
```

It loads, but it is not further tested yet and thus probably still buggy for eggdrop 1.8, esp. the changed http-part.

Due to the changed module API, versions of stats.mod before this PR will only work until eggdrop 1.8-rc1 and versions of stats mod with/after this PR will only work from eggdrop 1.8-rc1. Choose your poison ;) I guess its possible to ifdef code, so that it would work for all versions, but this i leave for someone else to do, should there be interest.