### PR TITLE
Fix heap-buffer-overflow

### DIFF
--- a/UPDATES
+++ b/UPDATES
@@ -1,9 +1,14 @@
 Changes in Stats.mod: (since v1.0.1)
 --------------------
+
+1.5.1
+- fix heap overflow
+
 1.5.0
-- Now also works with eggdrop 1.8. stats 1.4.1 does not work with
-  eggdrop 1.8-rc1+ / git ac1b6ed3f4f949affd7090a053787fb664f4e292+.
-- Fix crash if no language selected.
+- fix crash if no language selected (Michael Ortmann)
+- now also works with eggdrop 1.8. stats 1.4.1 does not work with
+  eggdrop 1.8-rc1+ / git ac1b6ed3f4f949affd7090a053787fb664f4e292+ (Michael
+  Ortmann)
 
 1.4.1
 - Now also works with eggdrop 1.8.

--- a/UPDATES
+++ b/UPDATES
@@ -2,7 +2,7 @@ Changes in Stats.mod: (since v1.0.1)
 --------------------
 
 1.5.1
-- fix heap overflow
+- fix heap overflow (Michael Ortmann)
 
 1.5.0
 - fix crash if no language selected (Michael Ortmann)

--- a/core/slang.c
+++ b/core/slang.c
@@ -151,7 +151,7 @@ static int slang_load(struct slang_header *slang, char *filename)
 #ifndef SLANG_NOTYPES
   char *type;
 #endif
-  int line, id, iplace, itype;
+  int line, id, iplace, itype, l;
 
   Assert(slang);
   putlog(LOG_MISC, "*", "Loading language \"%s\" from %s...", slang->lang, filename);
@@ -167,11 +167,9 @@ static int slang_load(struct slang_header *slang, char *filename)
     if (fgets(s, 2000, f)) {
       line++;
       // at first, kill those stupid line feeds and carriage returns...
-      if (s[strlen(s) - 1] == '\n')
-        s[strlen(s) - 1] = 0;
-      if (s[strlen(s) - 1] == '\r')
-        s[strlen(s) - 1] = 0;
-      if (!s[0])
+      for (l = strlen(s); l && ((s[l - 1] == '\n') || (s[l - 1] == '\r')); l--)
+        s[l - 1] = 0;
+      if (!l)
         continue;
       cmd = newsplit(&s);
 

--- a/stats.c
+++ b/stats.c
@@ -31,7 +31,7 @@
 
 #define MAKING_STATS
 #define MODULE_NAME "stats"
-#define MODULE_VERSION "1.5.0"
+#define MODULE_VERSION "1.5.1"
 #ifndef NO_EGG
 #include "../module.h"
 #include "../irc.mod/irc.h"


### PR DESCRIPTION
```
Loading language "en" from language/stats.en.lang...
=================================================================
==76895==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x61d00000007f at pc 0x7fb6d8f80f87 bp 0x7ffc635ec660 sp 0x7ffc635ec650
READ of size 1 at 0x61d00000007f thread T0
    #0 0x7fb6d8f80f86 in slang_load core/slang.c:172
    #1 0x7fb6d8f81a09 in tcl_loadstatslang /home/michael/projects/eggdrop/src/mod/stats.mod/tclstats.c:185
    #2 0x55e124659a39 in tcl_call_stringproc_cd /home/michael/projects/eggdrop/src/tcl.c:324
    #3 0x55e124659b8a in tcl_call_stringproc /home/michael/projects/eggdrop/src/tcl.c:333
    #4 0x7fb6ded8dc61 in TclNRRunCallbacks (/usr/lib/libtcl8.6.so+0x40c61)
    #5 0x7fb6ded8fb39 in TclEvalEx (/usr/lib/libtcl8.6.so+0x42b39)
    #6 0x7fb6dee4a369 in Tcl_FSEvalFileEx (/usr/lib/libtcl8.6.so+0xfd369)
    #7 0x7fb6dee4a509 in Tcl_EvalFile (/usr/lib/libtcl8.6.so+0xfd509)
    #8 0x55e12465cfdf in readtclprog /home/michael/projects/eggdrop/src/tcl.c:814
    #9 0x55e1245ba8ac in chanprog /home/michael/projects/eggdrop/src/chanprog.c:461
    #10 0x55e12462fbc2 in main main.c:1162
    #11 0x7fb6ddd34171 in __libc_start_main (/usr/lib/libc.so.6+0x28171)
    #12 0x55e12458030d in _start (/home/michael/eggdrop/eggdrop-1.9.0+0x20730d)

0x61d00000007f is located 1 bytes to the left of 2000-byte region [0x61d000000080,0x61d000000850)
allocated by thread T0 here:
    #0 0x7fb6defc5459 in __interceptor_malloc /build/gcc/src/gcc/libsanitizer/asan/asan_malloc_linux.cpp:145
    #1 0x7fb6d8f2ccce in dmd_malloc core/dynamic_mem_debug.c:119

SUMMARY: AddressSanitizer: heap-buffer-overflow core/slang.c:172 in slang_load
Shadow bytes around the buggy address:
  0x0c3a7fff7fb0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c3a7fff7fc0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c3a7fff7fd0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c3a7fff7fe0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c3a7fff7ff0: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
=>0x0c3a7fff8000: fa fa fa fa fa fa fa fa fa fa fa fa fa fa fa[fa]
  0x0c3a7fff8010: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c3a7fff8020: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c3a7fff8030: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c3a7fff8040: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
  0x0c3a7fff8050: 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07 
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
  Shadow gap:              cc
==76895==ABORTING
```